### PR TITLE
remove specific psych gem version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     yalphabetize (0.4.1)
-      psych (~> 3)
 
 GEM
   remote: https://rubygems.org/
@@ -30,7 +29,6 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    psych (3.3.2)
     rainbow (3.0.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)

--- a/yalphabetize.gemspec
+++ b/yalphabetize.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.authors     = ['Sam Jenkins']
   s.files       = Dir['{bin,lib}/**/*']
   s.executables << 'yalphabetize'
-  s.add_runtime_dependency 'psych', '~> 3'
   s.add_development_dependency 'factory_bot'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
The Rubocop gem experimented with adding Psych as a runtime dependency. This didn't work and they reverted the move:
https://github.com/rubocop/rubocop/pull/6885

According to the Rubocop PR above, Psych is tightly coupled to Ruby core and it is dangerous to spec a specific Psych version without requiring a matching Ruby version.

Instead, we should rely on the version of Psych shipped with the Ruby version being used.