### PR TITLE
explicitly support Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu, macos, windows ]
-        ruby: [ '2.7', '3.0', '3.1', 'head' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
     steps:
       - name: windows misc
         if: matrix.os == 'windows'


### PR DESCRIPTION
Running against HEAD ruby version is flaky. We should run against explicit ruby versions only.