### PR TITLE
use github actions bundler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: install dependencies
-        run:  bundle install --jobs 3 --retry 3
+          bundler-cache: true
       - name: spec
         run:  bundle exec rspec
       - name: rubocop

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 3.0
-      - run: bundle install
+          bundler-cache: true
       - id: published_version
         run: echo ::set-output name=published_version::$(gem list yalphabetize --remote | tail -n 1 | cut -d "(" -f2 | cut -d ")" -f1)
       - id: bundled_version


### PR DESCRIPTION
I never originally implemented a caching for bundler. This will speed up CI A LOT!!