### PR TITLE
Handle newline comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     yalphabetize (0.9.0)
+      psych-comments
 
 GEM
   remote: https://rubygems.org/
@@ -45,6 +46,7 @@ GEM
       racc
     psych (5.1.2)
       stringio
+    psych-comments (0.1.1)
     racc (1.7.3)
     rainbow (3.1.1)
     rdoc (6.6.3.1)

--- a/README.md
+++ b/README.md
@@ -183,6 +183,52 @@ numbers_extended:
   zero: 0
 ```
 
+## Handling YAML comments
+
+Yalphabetize will preserve all YAML comments which start on their own line. Yaml will not preserve inline comments (see
+[known issues](#known-issues)). When Yalphabetize autocorrects the ordering of a YAML file, comments will be reordered
+with the YAML line immediately following them. For example:
+```yml
+# Bananas are long
+bananas: 2
+# Apples are round
+apples: 1
+```
+becomes
+```yml
+# Apples are round
+apples: 1
+# Bananas are long
+bananas: 2
+```
+Comments at the end of a YAML document remain at the end of the document. For example:
+```yml
+bananas: 2
+apples: 1
+# This comment is at the end
+```
+becomes
+```yml
+apples: 1
+bananas: 2
+# This comment is at the end
+```
+To ensure comments remain at the top of a YAML file, they should be placed before the start of the YAML document. For
+example:
+```yml
+# This comment is at the start
+---
+bananas: 2
+apples: 1
+```
+becomes
+```yml
+# This comment is at the start
+---
+apples: 1
+bananas: 2
+```
+
 ## Adding yalphabetize to your project's CI
 
 Yalphabetize is a great addition to any linting you might currently perform as part of CI. The `yalphabetize` executable
@@ -209,8 +255,9 @@ We currently support:
 - MRI 3.1 - 3.3
 
 ## Known issues
-- Yalphabetize cannot currently preserve comments while automatically alphabetising a YAML file. Comments will have to
-be replaced after the alphabetisation.
+- Yalphabetize cannot currently preserve inline comments while automatically alphabetising a YAML file. We recommend
+that you refactor any inline comments onto their own line. Otherwise, any inline comments will have to be replaced after
+alphabetisation.
 
 ## Contribute
 

--- a/lib/yalphabetize.rb
+++ b/lib/yalphabetize.rb
@@ -28,7 +28,8 @@ module Yalphabetize
       'indent_sequences' => true,
       'exclude' => [],
       'only' => [],
-      'sort_by' => 'ABab'
+      'sort_by' => 'ABab',
+      'preserve_comments' => true
     }.freeze
 
     def config

--- a/lib/yalphabetize/reader.rb
+++ b/lib/yalphabetize/reader.rb
@@ -22,7 +22,7 @@ module Yalphabetize
     end
 
     def stream_node
-      @_stream_node ||= Psych::Comments.parse_stream file
+      @_stream_node ||= parser_class.parse_stream file
     rescue Psych::SyntaxError => e
       raise Yalphabetize::ParsingError.new(
         path,
@@ -32,6 +32,14 @@ module Yalphabetize
         e.problem,
         e.context
       )
+    end
+
+    def parser_class
+      if Yalphabetize.config['preserve_comments']
+        Psych::Comments
+      else
+        Psych
+      end
     end
   end
 end

--- a/lib/yalphabetize/reader.rb
+++ b/lib/yalphabetize/reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'psych'
+require 'psych/comments'
 
 module Yalphabetize
   class Reader
@@ -21,7 +22,7 @@ module Yalphabetize
     end
 
     def stream_node
-      @_stream_node ||= Psych.parse_stream file
+      @_stream_node ||= Psych::Comments.parse_stream file
     rescue Psych::SyntaxError => e
       raise Yalphabetize::ParsingError.new(
         path,

--- a/lib/yalphabetize/writer.rb
+++ b/lib/yalphabetize/writer.rb
@@ -20,7 +20,11 @@ module Yalphabetize
     attr_reader :stream_node, :path
 
     def new_file_content
-      @_new_file_content ||= Psych::Comments.emit_yaml stream_node
+      @_new_file_content ||= if Yalphabetize.config['preserve_comments']
+                               Psych::Comments.emit_yaml stream_node
+                             else
+                               stream_node.to_yaml(nil, line_width: MAX_LINE_WIDTH)
+                             end
     end
 
     def indent_sequences

--- a/lib/yalphabetize/writer.rb
+++ b/lib/yalphabetize/writer.rb
@@ -20,7 +20,7 @@ module Yalphabetize
     attr_reader :stream_node, :path
 
     def new_file_content
-      @_new_file_content ||= stream_node.to_yaml(nil, line_width: MAX_LINE_WIDTH)
+      @_new_file_content ||= Psych::Comments.emit_yaml stream_node
     end
 
     def indent_sequences

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+RSpec.describe 'comment' do
+  it 'autocorrect does nothing to # literals in strings' do
+    expect_offence(<<~YAML)
+      Bananas: '2 # not a comment 2'
+      Apples: '1 # not a comment 1'
+    YAML
+
+    expect_reordering(<<~YAML)
+      Apples: '1 # not a comment 1'
+      Bananas: '2 # not a comment 2'
+    YAML
+  end
+
+  it 'autocorrect preserves newline comments above the proceeding YAML' do
+    expect_offence(<<~YAML)
+      # Bananas comment 1
+      # Bananas comment 2
+      Bananas: 2
+      # Apples comment 1
+      # Apples comment 2
+      Apples: 1
+    YAML
+
+    expect_reordering(<<~YAML)
+      # Apples comment 1
+      # Apples comment 2
+      Apples: 1
+      # Bananas comment 1
+      # Bananas comment 2
+      Bananas: 2
+    YAML
+  end
+
+  it 'autocorrect preserves newline comments before the start of a doc' do
+    expect_offence(<<~YAML)
+      # Comment 1
+      # Comment 2
+      ---
+      Bananas: 2
+      Apples: 1
+    YAML
+
+    expect_reordering(<<~YAML)
+      # Comment 1
+      # Comment 2
+      ---
+      Apples: 1
+      Bananas: 2
+    YAML
+  end
+
+  it 'autocorrect preserves newline comments before end of a doc' do
+    expect_offence(<<~YAML)
+      Bananas: 2
+      Apples: 1
+      # Comment 1
+      # Comment 2
+    YAML
+
+    expect_reordering(<<~YAML)
+      Apples: 1
+      Bananas: 2
+      # Comment 1
+      # Comment 2
+    YAML
+  end
+
+  it 'autocorrect preserved newline comments after end of a doc' do
+    expect_offence(<<~YAML)
+      Bananas: 2
+      Apples: 1
+      ...
+      # Comment 1
+      # Comment 2
+    YAML
+
+    expect_reordering(<<~YAML)
+      Apples: 1
+      Bananas: 2
+      ...
+      # Comment 1
+      # Comment 2
+    YAML
+  end
+end

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -84,4 +84,24 @@ RSpec.describe 'comment' do
       # Comment 2
     YAML
   end
+
+  context 'when preserve_comments is disabled' do
+    include_context 'with configuration', 'preserve_comments' => false
+
+    it 'removes comments during autocorrect' do
+      expect_offence(<<~YAML)
+        # Bananas comment 1
+        # Bananas comment 2
+        Bananas: 2
+        # Apples comment 1
+        # Apples comment 2
+        Apples: 1
+      YAML
+
+      expect_reordering(<<~YAML)
+        Apples: 1
+        Bananas: 2
+      YAML
+    end
+  end
 end

--- a/spec/yalphabetize/reader_spec.rb
+++ b/spec/yalphabetize/reader_spec.rb
@@ -8,11 +8,26 @@ RSpec.describe Yalphabetize::Reader do
 
     it { is_expected.to be_a Psych::Nodes::Stream }
 
-    it 'opens and parses the file' do
-      expect(File).to receive(:read).with(file_path).and_return('the_file')
-      expect(Psych::Comments).to receive(:parse_stream).with('the_file').and_return('the_parsed_file')
+    context 'when preserve_comments is enabled' do
+      include_context 'with configuration', 'preserve_comments' => true
 
-      expect(subject).to eq 'the_parsed_file'
+      it 'opens and parses the file' do
+        expect(File).to receive(:read).with(file_path).and_return('the_file')
+        expect(Psych::Comments).to receive(:parse_stream).with('the_file').and_return('the_parsed_file_with_comments')
+
+        expect(subject).to eq 'the_parsed_file_with_comments'
+      end
+    end
+
+    context 'when preserve_comments is disabled' do
+      include_context 'with configuration', 'preserve_comments' => false
+
+      it 'opens and parses the file' do
+        expect(File).to receive(:read).with(file_path).and_return('the_file')
+        expect(Psych).to receive(:parse_stream).with('the_file').and_return('the_parsed_file_without_comments')
+
+        expect(subject).to eq 'the_parsed_file_without_comments'
+      end
     end
 
     context 'when yaml contains parseable i18n interpolations' do

--- a/spec/yalphabetize/reader_spec.rb
+++ b/spec/yalphabetize/reader_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Yalphabetize::Reader do
 
     it 'opens and parses the file' do
       expect(File).to receive(:read).with(file_path).and_return('the_file')
-      expect(Psych).to receive(:parse_stream).with('the_file').and_return('the_parsed_file')
+      expect(Psych::Comments).to receive(:parse_stream).with('the_file').and_return('the_parsed_file')
 
       expect(subject).to eq 'the_parsed_file'
     end

--- a/spec/yalphabetize_spec.rb
+++ b/spec/yalphabetize_spec.rb
@@ -9,7 +9,8 @@ RSpec.describe Yalphabetize do
         'indent_sequences' => true,
         'exclude' => [],
         'only' => [],
-        'sort_by' => 'ABab'
+        'sort_by' => 'ABab',
+        'preserve_comments' => true
       }
     end
 

--- a/yalphabetize.gemspec
+++ b/yalphabetize.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.metadata = {
     'rubygems_mfa_required' => 'true'
   }
+  s.add_runtime_dependency 'psych-comments'
 end


### PR DESCRIPTION
[psych-comments](https://github.com/wantedly/psych-comments) extends Ruby's YAML parser to also parse comments. Currently it will only parse newline comments. There is a PR open on the gem to add support for inline comments.

By making use of this gem, we can preserve newline comments when alphabetising a YAML file.