### PR TITLE
Return exit code 0 for corrected offenses

### DIFF
--- a/lib/yalphabetize/logger.rb
+++ b/lib/yalphabetize/logger.rb
@@ -36,7 +36,7 @@ module Yalphabetize
     end
 
     def uncorrected_offences?
-      @offences.value?(:detected)
+      offences.value?(:detected)
     end
 
     def log_correction(file_path)
@@ -58,7 +58,7 @@ module Yalphabetize
     end
 
     def list_offences_color
-      uncorrected_offences? ? :red : :green
+      offences.any? ? :red : :green
     end
 
     def red(string)

--- a/lib/yalphabetize/logger.rb
+++ b/lib/yalphabetize/logger.rb
@@ -35,7 +35,6 @@ module Yalphabetize
       output.puts 'Offences can be automatically fixed with `-a` or `--autocorrect`'
     end
 
-
     def uncorrected_offences?
       @offences.value?(:detected)
     end

--- a/lib/yalphabetize/logger.rb
+++ b/lib/yalphabetize/logger.rb
@@ -39,6 +39,10 @@ module Yalphabetize
       @offences.any?
     end
 
+    def uncorrected_offences?
+      @offences.value?(:detected)
+    end
+
     def log_correction(file_path)
       offences[file_path] = :corrected
     end

--- a/lib/yalphabetize/logger.rb
+++ b/lib/yalphabetize/logger.rb
@@ -30,14 +30,11 @@ module Yalphabetize
       output.puts send(list_offences_color, "Offences: #{offences.size}")
 
       offences.each { |file_path, status| puts_offence(file_path, status) }
-      return unless offences?
+      return unless uncorrected_offences?
 
       output.puts 'Offences can be automatically fixed with `-a` or `--autocorrect`'
     end
 
-    def offences?
-      @offences.any?
-    end
 
     def uncorrected_offences?
       @offences.value?(:detected)
@@ -62,7 +59,7 @@ module Yalphabetize
     end
 
     def list_offences_color
-      offences? ? :red : :green
+      uncorrected_offences? ? :red : :green
     end
 
     def red(string)

--- a/lib/yalphabetize/yalphabetizer.rb
+++ b/lib/yalphabetize/yalphabetizer.rb
@@ -56,7 +56,7 @@ module Yalphabetize
 
     def final_log
       logger.final_summary
-      logger.offences? ? 1 : 0
+      logger.uncorrected_offences? ? 1 : 0
     end
 
     def reader_class

--- a/spec/yalphabetize/logger_spec.rb
+++ b/spec/yalphabetize/logger_spec.rb
@@ -41,4 +41,31 @@ RSpec.describe Yalphabetize::Logger do
       end
     end
   end
+
+  describe '#uncorrected_offences?' do
+    before do
+      # silence offence output
+      allow($stdout).to receive(:write)
+    end
+
+    context 'when there is at least one uncorrected offence' do
+      subject do
+        logger.log_correction('corrected_dummy_path')
+        logger.log_offence('uncorrected_dummy_path')
+        logger.uncorrected_offences?
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when all offences have been corrected' do
+      subject do
+        logger.log_correction('correction_dummy_path1')
+        logger.log_correction('correction_dummy_path2')
+        logger.uncorrected_offences?
+      end
+
+      it { is_expected.to be_falsey }
+    end
+  end
 end

--- a/spec/yalphabetize/logger_spec.rb
+++ b/spec/yalphabetize/logger_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 RSpec.describe Yalphabetize::Logger do
-  let(:logger) { described_class.new($stdout) }
+  let(:logger) { described_class.new }
 
   describe '#initial_summary' do
     subject { logger.initial_summary(%w[path1 path2 path3]) }
+
+    let(:logger) { described_class.new($stdout) }
 
     it 'logs the number of YAML files being inspected' do
       expect { subject }.to output("Inspecting 3 YAML files\n").to_stdout
@@ -13,6 +15,8 @@ RSpec.describe Yalphabetize::Logger do
 
   describe '#final_summary' do
     subject { logger.final_summary }
+
+    let(:logger) { described_class.new($stdout) }
 
     context 'when no offences have been detected' do
       it 'logs the expected output' do
@@ -43,11 +47,6 @@ RSpec.describe Yalphabetize::Logger do
   end
 
   describe '#uncorrected_offences?' do
-    before do
-      # silence offence output
-      allow($stdout).to receive(:write)
-    end
-
     context 'when there is at least one uncorrected offence' do
       subject do
         logger.log_correction('corrected_dummy_path')


### PR DESCRIPTION
Currently when autocorrecting a file, yalphabetize returns a non-zero exit code even when all offenses have been successfully fixed.  This has created issues for some tooling (such as CI, or pre-commit hooks), since the failure returned by yalphabetize, can subsequently cause the rest of the toolchain to fail as well.

This PR modifies this behavior so that a non-zero exit code will be returned only if uncorrected offenses are still present.  This aligns with how exit codes are handled by other formatters such as `eslint` and `prettier`