### PR TITLE
add stdout tests

### DIFF
--- a/lib/yalphabetize/logger.rb
+++ b/lib/yalphabetize/logger.rb
@@ -2,37 +2,36 @@
 
 module Yalphabetize
   class Logger
-    DEFAULT_OUTPUT = $stdout
+    DEFAULT_OUTPUT = Kernel
 
-    def initialize(output = DEFAULT_OUTPUT)
-      @output = output
+    def initialize
       @inspected_count = 0
       @offences = {}
     end
 
     def initial_summary(file_paths)
-      output.puts "Inspecting #{file_paths.size} YAML files"
+      DEFAULT_OUTPUT.puts "Inspecting #{file_paths.size} YAML files"
     end
 
     def log_offence(file_path)
       self.inspected_count += 1
       offences[file_path] = :detected
-      output.print red 'O'
+      DEFAULT_OUTPUT.print red 'O'
     end
 
     def log_no_offence
       self.inspected_count += 1
-      output.print green '.'
+      DEFAULT_OUTPUT.print green '.'
     end
 
     def final_summary
-      output.puts "\nInspected: #{inspected_count}"
-      output.puts send(list_offences_color, "Offences: #{offences.size}")
+      DEFAULT_OUTPUT.puts "\nInspected: #{inspected_count}"
+      DEFAULT_OUTPUT.puts send(list_offences_color, "Offences: #{offences.size}")
 
       offences.each { |file_path, status| puts_offence(file_path, status) }
       return unless uncorrected_offences?
 
-      output.puts 'Offences can be automatically fixed with `-a` or `--autocorrect`'
+      DEFAULT_OUTPUT.puts 'Offences can be automatically fixed with `-a` or `--autocorrect`'
     end
 
     def uncorrected_offences?
@@ -45,15 +44,15 @@ module Yalphabetize
 
     private
 
-    attr_reader :offences, :output
+    attr_reader :offences
     attr_accessor :inspected_count
 
     def puts_offence(file_path, status)
       case status
       when :detected
-        output.puts yellow file_path
+        DEFAULT_OUTPUT.puts yellow file_path
       when :corrected
-        output.puts("#{yellow(file_path)} #{green('CORRECTED')}")
+        DEFAULT_OUTPUT.puts("#{yellow(file_path)} #{green('CORRECTED')}")
       end
     end
 

--- a/lib/yalphabetize/yaml_finder.rb
+++ b/lib/yalphabetize/yaml_finder.rb
@@ -25,7 +25,7 @@ module Yalphabetize
         process_paths(paths)
       end
 
-      files.flatten.select { |file| valid?(file) }.map { |f| File.expand_path(f) }.uniq
+      files.flatten.select { |file| valid?(file) }.uniq
     end
 
     private
@@ -56,7 +56,7 @@ module Yalphabetize
         '--exclude-standard', '--others', '--cached', '--modified'
       )
 
-      output.split("\0").uniq.map { |git_file| "#{Dir.pwd}/#{git_file}" } if status.success?
+      output.split("\0").uniq if status.success?
     end
 
     def valid?(path)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,12 +116,12 @@ RSpec.configure do |config|
   end
 
   config.before do
-    stub_const('Yalphabetize::Logger::DEFAULT_OUTPUT', double.as_null_object)
-  end
-
-  config.before do
     FileUtils.remove_dir('spec/tmp', true)
     Dir.mkdir('spec/tmp')
+  end
+
+  config.before do |example|
+    stub_const('Yalphabetize::Logger::DEFAULT_OUTPUT', double.as_null_object) unless example.metadata[:enable_logging]
   end
 
   config.after { FileUtils.remove_dir('spec/tmp', true) }

--- a/spec/yalphabetize/logger_spec.rb
+++ b/spec/yalphabetize/logger_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe Yalphabetize::Logger do
   describe '#initial_summary' do
     subject { logger.initial_summary(%w[path1 path2 path3]) }
 
-    let(:logger) { described_class.new($stdout) }
-
-    it 'logs the number of YAML files being inspected' do
+    it 'logs the number of YAML files being inspected', :enable_logging do
       expect { subject }.to output("Inspecting 3 YAML files\n").to_stdout
     end
   end
@@ -16,10 +14,8 @@ RSpec.describe Yalphabetize::Logger do
   describe '#final_summary' do
     subject { logger.final_summary }
 
-    let(:logger) { described_class.new($stdout) }
-
     context 'when no offences have been detected' do
-      it 'logs the expected output' do
+      it 'logs the expected output', :enable_logging do
         expect { subject }.to output("\nInspected: 0\n\e[32mOffences: 0\e[0m\n").to_stdout
       end
     end
@@ -40,7 +36,7 @@ RSpec.describe Yalphabetize::Logger do
         STR
       end
 
-      it 'logs the expected output' do
+      it 'logs the expected output', :enable_logging do
         expect { subject }.to output(expected_output).to_stdout
       end
     end

--- a/spec/yalphabetize/yalphabetizer_spec.rb
+++ b/spec/yalphabetize/yalphabetizer_spec.rb
@@ -40,5 +40,197 @@ RSpec.describe Yalphabetize::Yalphabetizer do
         subject
       end
     end
+
+    describe 'stdout' do
+      let(:args) { ['spec/tmp'] }
+
+      context 'when inspecting 0 files' do
+        it 'outputs 0 file message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 0 YAML files
+
+            Inspected: 0
+            \e[32mOffences: 0\e[0m
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 1 empty file' do
+        before { create_empty_file('1.yml') }
+
+        it 'outputs 1 file message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 1 YAML files
+            \e[32m.\e[0m
+            Inspected: 1
+            \e[32mOffences: 0\e[0m
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 2 empty files' do
+        before do
+          create_empty_file('1.yml')
+          create_empty_file('2.yml')
+        end
+
+        it 'outputs 2 file message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 2 YAML files
+            \e[32m.\e[0m\e[32m.\e[0m
+            Inspected: 2
+            \e[32mOffences: 0\e[0m
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 1 offending file without autocorrect' do
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before { create_file('1.yml', unordered_yaml) }
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 1 YAML files
+            \e[31mO\e[0m
+            Inspected: 1
+            \e[31mOffences: 1\e[0m
+            \e[33mspec/tmp/1.yml\e[0m
+            Offences can be automatically fixed with `-a` or `--autocorrect`
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 1 offending file and 1 empty file without autocorrect' do
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before do
+          create_empty_file('1.yml')
+          create_file('2.yml', unordered_yaml)
+        end
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 2 YAML files
+            \e[32m.\e[0m\e[31mO\e[0m
+            Inspected: 2
+            \e[31mOffences: 1\e[0m
+            \e[33mspec/tmp/2.yml\e[0m
+            Offences can be automatically fixed with `-a` or `--autocorrect`
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 1 offending file with autocorrect' do
+        let(:opts) { { autocorrect: true } }
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before { create_file('1.yml', unordered_yaml) }
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 1 YAML files
+            \e[31mO\e[0m
+            Inspected: 1
+            \e[31mOffences: 1\e[0m
+            \e[33mspec/tmp/1.yml\e[0m \e[32mCORRECTED\e[0m
+          STDOUT
+        end
+      end
+
+      context 'when inspecting 1 offending file and 1 empty file with autocorrect' do
+        let(:opts) { { autocorrect: true } }
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before do
+          create_empty_file('1.yml')
+          create_file('2.yml', unordered_yaml)
+        end
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 2 YAML files
+            \e[32m.\e[0m\e[31mO\e[0m
+            Inspected: 2
+            \e[31mOffences: 1\e[0m
+            \e[33mspec/tmp/2.yml\e[0m \e[32mCORRECTED\e[0m
+          STDOUT
+        end
+      end
+
+      context 'when inspecting multiple offending files and multiple empty files without autocorrect' do
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before do
+          [1, 2, 5, 6, 8].each { |i| create_empty_file("#{i}.yml") }
+          [3, 4, 7].each { |i| create_file("#{i}.yml", unordered_yaml) }
+        end
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 8 YAML files
+            \e[32m.\e[0m\e[32m.\e[0m\e[31mO\e[0m\e[31mO\e[0m\e[32m.\e[0m\e[32m.\e[0m\e[31mO\e[0m\e[32m.\e[0m
+            Inspected: 8
+            \e[31mOffences: 3\e[0m
+            \e[33mspec/tmp/3.yml\e[0m
+            \e[33mspec/tmp/4.yml\e[0m
+            \e[33mspec/tmp/7.yml\e[0m
+            Offences can be automatically fixed with `-a` or `--autocorrect`
+          STDOUT
+        end
+      end
+
+      context 'when inspecting multiple offending files and multiple empty files with autocorrect' do
+        let(:opts) { { autocorrect: true } }
+        let(:unordered_yaml) do
+          <<~YAML
+            bananas: 2
+            apples: 1
+          YAML
+        end
+
+        before do
+          [1, 2, 5, 6, 8].each { |i| create_empty_file("#{i}.yml") }
+          [3, 4, 7].each { |i| create_file("#{i}.yml", unordered_yaml) }
+        end
+
+        it 'outputs 1 offence message to stdout', :enable_logging do
+          expect { subject }.to output(<<~STDOUT).to_stdout
+            Inspecting 8 YAML files
+            \e[32m.\e[0m\e[32m.\e[0m\e[31mO\e[0m\e[31mO\e[0m\e[32m.\e[0m\e[32m.\e[0m\e[31mO\e[0m\e[32m.\e[0m
+            Inspected: 8
+            \e[31mOffences: 3\e[0m
+            \e[33mspec/tmp/3.yml\e[0m \e[32mCORRECTED\e[0m
+            \e[33mspec/tmp/4.yml\e[0m \e[32mCORRECTED\e[0m
+            \e[33mspec/tmp/7.yml\e[0m \e[32mCORRECTED\e[0m
+          STDOUT
+        end
+      end
+    end
   end
 end

--- a/spec/yalphabetize/yaml_finder_spec.rb
+++ b/spec/yalphabetize/yaml_finder_spec.rb
@@ -24,10 +24,10 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yml_in_sub_dir.yml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yml_in_sub_dir.yml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -39,8 +39,8 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory except those in excluded directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml'
             )
           end
         end
@@ -52,9 +52,9 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory excluding the one file' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -66,10 +66,10 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yml_in_sub_dir.yml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yml_in_sub_dir.yml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -81,8 +81,8 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory excluding those matching the glob' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -94,10 +94,10 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yml_in_sub_dir.yml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yml_in_sub_dir.yml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -109,10 +109,10 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('yml_in_top_dir.yml'),
-              File.expand_path('yaml_in_top_dir.yaml'),
-              File.expand_path('sub_dir/yml_in_sub_dir.yml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'yml_in_top_dir.yml',
+              'yaml_in_top_dir.yaml',
+              'sub_dir/yml_in_sub_dir.yml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -124,8 +124,8 @@ RSpec.describe Yalphabetize::YamlFinder do
         it 'lists all yaml files in working directory' do
           Dir.chdir('spec/tmp') do
             expect(subject).to contain_exactly(
-              File.expand_path('sub_dir/yml_in_sub_dir.yml'),
-              File.expand_path('sub_dir/yaml_in_sub_dir.yaml')
+              'sub_dir/yml_in_sub_dir.yml',
+              'sub_dir/yaml_in_sub_dir.yaml'
             )
           end
         end
@@ -137,8 +137,8 @@ RSpec.describe Yalphabetize::YamlFinder do
 
       it 'lists all yaml files in specified directory' do
         expect(subject).to contain_exactly(
-          File.expand_path('spec/tmp/sub_dir/yml_in_sub_dir.yml'),
-          File.expand_path('spec/tmp/sub_dir/yaml_in_sub_dir.yaml')
+          'spec/tmp/sub_dir/yml_in_sub_dir.yml',
+          'spec/tmp/sub_dir/yaml_in_sub_dir.yaml'
         )
       end
 
@@ -146,7 +146,7 @@ RSpec.describe Yalphabetize::YamlFinder do
         let(:exclude) { ['spec/tmp/sub_dir/yml_in_sub_dir.yml'] }
 
         it 'lists all yaml files in specified directory excluding the specified file' do
-          expect(subject).to contain_exactly(File.expand_path('spec/tmp/sub_dir/yaml_in_sub_dir.yaml'))
+          expect(subject).to contain_exactly('spec/tmp/sub_dir/yaml_in_sub_dir.yaml')
         end
       end
     end
@@ -155,7 +155,7 @@ RSpec.describe Yalphabetize::YamlFinder do
       let(:only) { ['spec/tmp/sub_dir/yml_in_sub_dir.yml'] }
 
       it 'lists only the specified file' do
-        expect(subject).to contain_exactly(File.expand_path('spec/tmp/sub_dir/yml_in_sub_dir.yml'))
+        expect(subject).to contain_exactly('spec/tmp/sub_dir/yml_in_sub_dir.yml')
       end
     end
 
@@ -172,9 +172,9 @@ RSpec.describe Yalphabetize::YamlFinder do
 
       it 'lists all specified yaml files and yaml files in specified directories' do
         expect(subject).to contain_exactly(
-          File.expand_path('spec/tmp/yml_in_top_dir.yml'),
-          File.expand_path('spec/tmp/sub_dir/yml_in_sub_dir.yml'),
-          File.expand_path('spec/tmp/sub_dir/yaml_in_sub_dir.yaml')
+          'spec/tmp/yml_in_top_dir.yml',
+          'spec/tmp/sub_dir/yml_in_sub_dir.yml',
+          'spec/tmp/sub_dir/yaml_in_sub_dir.yaml'
         )
       end
     end
@@ -184,8 +184,8 @@ RSpec.describe Yalphabetize::YamlFinder do
 
       it 'lists all matching files' do
         expect(subject).to contain_exactly(
-          File.expand_path('spec/tmp/yml_in_top_dir.yml'),
-          File.expand_path('spec/tmp/sub_dir/yml_in_sub_dir.yml')
+          'spec/tmp/yml_in_top_dir.yml',
+          'spec/tmp/sub_dir/yml_in_sub_dir.yml'
         )
       end
     end


### PR DESCRIPTION
We have no tests to protect against regression of output to stdout. This PR adds that.

In order to be able to test stdout, we had to refactor the way the logger is written. The new implementation is a bit simpler.