### PR TITLE
drop official Ruby 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, macos, ubuntu ]
-        ruby: [ '3.1', '3.2', '3.3', '3.4', 'head' ]
+        ruby: [ '3.2', '3.3', '3.4', 'head' ]
     steps:
       - name: windows misc
         if: matrix.os == 'windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1
+          ruby-version: 3.2
           bundler-cache: true
       - id: published_version
         run: echo "PUBLISHED_VERSION=$(gem list yalphabetize --remote | tail -n 1 | cut -d "(" -f2 | cut -d ")" -f1)" >> $GITHUB_OUTPUT

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 Gemspec/RequiredRubyVersion:
   Enabled: false
 Layout/EndOfLine:
@@ -27,7 +27,7 @@ RSpec/StubbedMock:
   Enabled: false
 Style/Documentation:
   Enabled: false
-require:
+plugins:
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rspec

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ script:
 We aim for yalphabetize to be compatible with all actively maintained Ruby versions.
 
 We currently support:
-- MRI 3.1 - 3.4
+- MRI 3.2 - 3.4
 
 ## Known issues
 - Yalphabetize cannot currently preserve inline comments while automatically alphabetising a YAML file. We recommend


### PR DESCRIPTION
Ruby 3.1 reached EOL 31 March 2025

https://endoflife.date/ruby