### PR TITLE
add constraint <2 to parallel version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 gem 'debug'
 gem 'factory_bot'
+gem 'parallel', '< 2'
 gem 'rspec'
 gem 'rubocop'
 gem 'rubocop-factory_bot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ PLATFORMS
 DEPENDENCIES
   debug
   factory_bot
+  parallel (< 2)
   rspec
   rubocop
   rubocop-factory_bot


### PR DESCRIPTION
To ensure compatibility with Ruby < 3.3