### PR TITLE
add back ruby 3.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows, macos, ubuntu ]
-        ruby: [ '3.2', '3.3', '3.4', '4.0', 'head' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '4.0', 'head' ]
     steps:
       - name: windows misc
         if: matrix.os == 'windows'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 4.0
           bundler-cache: true
       - id: published_version
         run: echo "PUBLISHED_VERSION=$(gem list yalphabetize --remote | tail -n 1 | cut -d "(" -f2 | cut -d ")" -f1)" >> $GITHUB_OUTPUT

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.1
 Gemspec/RequiredRubyVersion:
   Enabled: false
 Layout/EndOfLine:

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gemspec
 
 gem 'debug'
 gem 'factory_bot'
-gem 'parallel', '< 2'
 gem 'rspec'
 gem 'rubocop'
 gem 'rubocop-factory_bot'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,24 +7,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (8.1.3)
+    activesupport (7.2.3.1)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
-      json
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
-      uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (4.1.2)
+    cgi (0.5.2)
     concurrent-ruby (1.3.7)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -32,7 +33,8 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.0)
     drb (2.2.3)
-    erb (6.0.1.1)
+    erb (4.0.4.1)
+      cgi (>= 0.3.3)
     factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     i18n (1.15.2)
@@ -46,9 +48,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    minitest (6.0.6)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -123,7 +123,6 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    uri (1.1.1)
 
 PLATFORMS
   ruby
@@ -133,7 +132,6 @@ PLATFORMS
 DEPENDENCIES
   debug
   factory_bot
-  parallel (< 2)
   rspec
   rubocop
   rubocop-factory_bot

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ script:
 We aim for yalphabetize to be compatible with all actively maintained Ruby versions.
 
 We currently support:
-- MRI 3.2 - 4.0
+- MRI 3.1 - 4.0
 
 ## Known issues
 - Yalphabetize cannot currently preserve inline comments while automatically alphabetising a YAML file. We recommend


### PR DESCRIPTION
If we can continue to support 3.1 without difficulty, let's do it