### PR TITLE
allow CI to fail on Ruby head

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   main:
     name: >-
       ${{ matrix.os }} ${{ matrix.ruby }}
+    continue-on-error: ${{ matrix.ruby == 'head' }}
     runs-on: ${{ matrix.os }}-latest
     env:
       # See https://github.com/tmm1/test-queue#environment-variables


### PR DESCRIPTION
head is unstable and unpublished and therefore liable to fail. This is not a reason to mark a CI run as having failed.