### PR TITLE
add ruby >= 2.7 requirement to gemspec

### DIFF
--- a/yalphabetize.gemspec
+++ b/yalphabetize.gemspec
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
     'source_code_uri' => "https://github.com/samrjenkins/yalphabetize/tree/v#{Yalphabetize::Version::STRING}",
     'rubygems_mfa_required' => 'true'
   }
+  s.required_ruby_version = '>= 2.7'
   s.add_dependency 'psych-comments'
 end


### PR DESCRIPTION
We are already incompatible with Ruby 2.6, so this constraint is backwards compatible with all supported Ruby versions.

This change helps us to avoid Dependabot PRs for incompatible dependency versions